### PR TITLE
Fix makefile to use installed mosquitto lib, and to use pack_rebuild()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PACKSODIR=lib/x86_64-linux
-MOSQUITTO_LIBS=-Lext ext/libmosquitto.a
+MOSQUITTO_LIBS=-lmosquitto
 SO=so
 SOEXT=so
 SOBJ=$(PACKSODIR)/mqtt.$(SOEXT)
@@ -8,7 +8,7 @@ CWFLAGS=-Wall
 CMFLAGS=-fno-strict-aliasing -pthread -fPIC -std=c99 
 CIFLAGS=-I. -Iext/include
 DEFS=
-CFLAGS=$(COFLAGS) $(CWFLAGS) $(CMFLAGS) $(CIFLAGS) $(PKGCFLAGS) $(DEFS)
+CFLAGS+=$(COFLAGS) $(CWFLAGS) $(CMFLAGS) $(CIFLAGS) $(PKGCFLAGS) $(DEFS)
 CXXFLAGS=$(CFLAGS)
 
 LD=gcc


### PR DESCRIPTION
After these changes the pack can be built in the normal swi prolog way:
`swipl -g 'pack_rebuild(mqtt)' -t 'halt(0)'`

It also uses the system installed mosquitto library. This prevents having to manually update the static mosquitto library and the mqtt pack will automatically use the updated mosquitto library from the system.